### PR TITLE
Suggest changing the sorting default to be "mean"

### DIFF
--- a/R/amp_rabund.R
+++ b/R/amp_rabund.R
@@ -20,7 +20,7 @@
 #' @param adjust.zero Keep 0 abundances in ggplot2 median calculations by adding a small constant to these.
 #' @param point.size Size of points (default: 2).
 #' @param output Either plot or complete (default: "plot").
-#' @param sort.by Sort the boxplot by either Median, Mean or Total (default = "Median")
+#' @param sort.by Sort the boxplot by either Median, Mean or Total (default = "Mean")
 #' @param plot.theme Chose different standard layouts choose from "normal" or "clean" (default: "normal").
 #' 
 #' @return A ggplot2 object
@@ -35,7 +35,7 @@
 #' 
 #' @author Mads Albertsen \email{MadsAlbertsen85@@gmail.com}
 
-amp_rabund <- function(data, group = "Sample", order.group = NULL, tax.show = 50, scale.seq = 10000, tax.clean = T, plot.type = "boxplot", plot.log = F, output = "plot", tax.add = NULL, tax.aggregate = "Genus", tax.empty = "best", tax.class = NULL, point.size = 2, plot.flip = F, sort.by = "Median", adjust.zero = NULL, plot.theme = "normal"){
+amp_rabund <- function(data, group = "Sample", order.group = NULL, tax.show = 50, scale.seq = 10000, tax.clean = T, plot.type = "boxplot", plot.log = F, output = "plot", tax.add = NULL, tax.aggregate = "Genus", tax.empty = "best", tax.class = NULL, point.size = 2, plot.flip = F, sort.by = "Mean", adjust.zero = NULL, plot.theme = "normal"){
   
   ## Check the input data type and convert to list if it's a phyloseq object
   data <- list(abund = as.data.frame(otu_table(data)@.Data),


### PR DESCRIPTION
Consider a set of 10 samples in two groups A (3 samples) and B (7 samples). 
if a species makes up 100 % in all samples of group A, but is not present in any samples of B. 
The median for this species will be ZERO, and when we then sort by the median this species would not occur in the plot!
Sorting by the mean (as is currently implemented in the amp_heatmap) would "solve" this problem.